### PR TITLE
Only depend on antlr4-runtime at runtime

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,8 +64,14 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
     antlr("org.antlr", "antlr4", "4.10.1")
+    implementation("org.antlr", "antlr4-runtime", "4.10.1")
 
     testImplementation(kotlin("test"))
+}
+
+// Exclude antlr4 from transitive dependencies (https://github.com/gradle/gradle/issues/820)
+configurations[JavaPlugin.API_CONFIGURATION_NAME].let { apiConfiguration ->
+    apiConfiguration.setExtendsFrom(apiConfiguration.extendsFrom.filter { it.name != "antlr" })
 }
 
 ktlint {


### PR DESCRIPTION
By default, the Gradle ANTLR plugin depends on the full ANTLR4 binary, which significantly bloats the dependency size where only the ANTLR runtime is required - see https://github.com/gradle/gradle/issues/820. This PR removes the ANTLR dependency from the `api` configuration used for Maven repository POMs, and adds a dependency on `antlr4-runtime`.