### PR TITLE
Fix problem with private members.

### DIFF
--- a/src/main/kotlin/cc/ekblad/toml/model/TomlException.kt
+++ b/src/main/kotlin/cc/ekblad/toml/model/TomlException.kt
@@ -59,4 +59,16 @@ sealed class TomlException : RuntimeException() {
         override val message: String
             get() = "toml decoding error: unable to encode '$sourceValue' into a toml value"
     }
+
+    /**
+     * An access error occurred while encoding a Kotlin value into a TOML value.
+     */
+    data class AccessError(
+        val name: String,
+        val tomlName: String,
+        override val cause: Throwable?
+    ) : TomlException() {
+        override val message: String
+            get() = "Cannot access constructor property: '$name' mapped from '$tomlName'"
+    }
 }

--- a/src/test/kotlin/cc/ekblad/toml/transcoder/BuiltinEncoderTests.kt
+++ b/src/test/kotlin/cc/ekblad/toml/transcoder/BuiltinEncoderTests.kt
@@ -181,6 +181,20 @@ class BuiltinEncoderTests : UnitTest {
     }
 
     @Test
+    fun can_encode_data_classes_with_private_properties() {
+        data class Foo(val foo: Int, private val bar: String) {
+            private val woof: String = "$foo $bar"
+        }
+        assertEncodesTo(
+            Foo(1, "text"),
+            TomlValue.Map(
+                "foo" to TomlValue.Integer(1),
+                "bar" to TomlValue.String("text"),
+            )
+        )
+    }
+
+    @Test
     fun `can encode TomlValues`() {
         fun assertEncodesToSelf(value: TomlValue) {
             assertEncodesTo(value, value)


### PR DESCRIPTION
The existing code encodes all the properties of a data class even ones not
in the primary constructor but only ever uses the primary constructor.
Any private properties cause this code to fail as we do not have access to
them (the isAccessible trick doesn't work on private properties that do not
have a backing store).

This changes the code to only encode the properties of the primary constructor's
parameters. As data classes only have property parameters in the primary
constructor, this is sufficient.

As part of reading the values the isAccessible flag is adjusted to make the
values accessible and now the logic resets the isAccessible flag to its original
value after processing.

Also added a check for IllegalAccessException that displays the parameter that
caused the problem to help with debugging in the future. In theory this won't
happen, but if something changes in how properties are handled in the future
this should help identify the issue.